### PR TITLE
Add aarch64_{linux,macos} install targets

### DIFF
--- a/src/zls.ts
+++ b/src/zls.ts
@@ -24,6 +24,8 @@ enum InstallationName {
   x86_64_linux = 'x86_64-linux',
   x86_64_macos = 'x86_64-macos',
   x86_64_windows = 'x86_64-windows',
+  aarch64_linux = 'aarch64-linux',
+  aarch64_macos = 'aarch64-macos',
 }
 
 function getDefaultInstallationName(): InstallationName | null {
@@ -36,6 +38,9 @@ function getDefaultInstallationName(): InstallationName | null {
     if (plat === 'linux') return InstallationName.x86_64_linux;
     else if (plat === 'darwin') return InstallationName.x86_64_macos;
     else if (plat === 'win32') return InstallationName.x86_64_windows;
+  } else if (arch === 'arm64') {
+    if (plat === 'linux') return InstallationName.aarch64_linux;
+    else if (plat === 'darwin') return InstallationName.aarch64_macos;
   }
   return null;
 }
@@ -68,7 +73,7 @@ export class Zls {
     }
 
     const debugLog = this.cfg.get<boolean>('debugLog')!;
-    return [zlsPath, debugLog ? ['--debug-log'] : []];
+    return [zlsPath, debugLog ? ['--enable-debug-log'] : []];
   }
 
   async install() {


### PR DESCRIPTION
also work with latest zls cli options --enable-debug-log:

```
~/personal/learn-zig via ↯ v0.10.1
❯ zls --version
0.11.0-dev.357+9a7d262
~/personal/learn-zig via ↯ v0.10.1
❯ zls --help
Usage: zls [command]

Commands:

  --help: Prints this message.
  --version: Prints the compiler version with which the server was compiled.
  --replay: Replay a previous recorded zls session
  --enable-debug-log: Enables debug logs.
  --show-config-path: Prints the path to the configuration file to stdout
  --config-path: Specify the path to a configuration file specifying LSP behaviour.
```